### PR TITLE
Gen eds are now retrieved from the database.

### DIFF
--- a/src/main/java/com/apc/luthercourseproposal/ApcController.java
+++ b/src/main/java/com/apc/luthercourseproposal/ApcController.java
@@ -224,6 +224,23 @@ public class ApcController extends HttpServlet {
                         status = STATUS_BAD_REQUEST;
                     }
                     break;
+                // ISSUE 29 (Database-driven gen eds): Add this case to the
+                // controller in order to properly service API requests for
+                // gen ed requirements. Makes a call to getAll, which works
+                // regardless of the collection passed to it. If response is OK,
+                // return the response. Otherwise return an empty response and
+                // say the request is bad. This is approximately identical to
+                // the other cases, such as departments.
+                // Also see proposal.js.
+                case "geneds":
+                    try {
+                        resp = this.dao.getAll(Collections.COLLECTION_GENEDS);
+                        status = STATUS_OK;
+                    } catch (Exception ex){
+                        resp = "";
+                        status = STATUS_BAD_REQUEST;
+                    }
+                    break;
                 case "archiveSearch":
                     try {
                         String searchString = request.getParameter("s");

--- a/src/main/java/com/apc/luthercourseproposal/ApcDao.java
+++ b/src/main/java/com/apc/luthercourseproposal/ApcDao.java
@@ -40,7 +40,11 @@ public class ApcDao {
         COLLECTION_USERS("users"),
         COLLECTION_PROPOSALS("proposals"),
         COLLECTION_DEPTS("depts"),
-        COLLECTION_ARCHIVES("archives");
+        COLLECTION_ARCHIVES("archives"),
+        // ISSUE 29 (Database-driven gen eds): Add this key to the enum so we can
+        // refer to the collection in ApcController.java.
+        // Also see proposal.js.
+        COLLECTION_GENEDS("geneds");
         
         private String name;
         

--- a/src/main/webapp/js/app.js
+++ b/src/main/webapp/js/app.js
@@ -52,14 +52,20 @@ function mainCtrl($rootScope, $scope, $log, $location, $q, $filter, authSrv, dat
      
     initData();
     
+    // ISSUE 29 (Database-driven gen eds): Here we simply add a call dataSrv.getGenEds()
+    // to the query in order to get all the gen eds from the database as defined
+    // in dataSrv. Then we set $scope.allGenEds = data[3] in order to save the gen
+    // eds in the scope.
+    // Also see proposal.js.
     function initData() { 
-        return $q.all([dataSrv.getProposals(), dataSrv.getCourses(), dataSrv.getDepts()]).then(function(data){
+        return $q.all([dataSrv.getProposals(), dataSrv.getCourses(), dataSrv.getDepts(), dataSrv.getGenEds()]).then(function(data){
             $scope.allProposals.elements = data[0];
             $scope.registrarData.elements = data[0].filter(pastAllStages);
             $log.debug($scope.registrarData);
             $log.debug($scope.user);
             $scope.courses = data[1];
             $scope.depts = data[2];
+            $scope.allGenEds = data[3];
             $scope.retrievingData = false;
         });
     }

--- a/src/main/webapp/js/dataSrv.js
+++ b/src/main/webapp/js/dataSrv.js
@@ -11,6 +11,7 @@ app.factory("dataSrv", ["$http", "$log", "$rootScope", "$filter", "DATA_URL", "E
 		getProposals : getProposals,
 		getRecentlyViewed : getRecent,
 		getDepts : getDepts,
+                getGenEds : getGenEds,  // ISSUE 29 (See definition below)
 		editUser : editUser,
 		saveProposal : saveProposal,
 		createProposal : createProposal,
@@ -105,6 +106,24 @@ app.factory("dataSrv", ["$http", "$log", "$rootScope", "$filter", "DATA_URL", "E
 			handleError(response);
 		});
 	}
+
+        // ISSUE 29 (Database-driven gen eds): Add this function to call the api 
+        // to query the database for gen eds. Also register it above.
+        // Also see proposal.js.
+        function getGenEds() {
+                return $http({
+                                        method : "GET",
+                                        url : DATA_URL,
+                                        params : {
+                                                q : "geneds"
+                                        }
+                }).then(function success(response) {
+                        $log.info("Retrieved gen eds data");
+                        return response.data;
+                }, function(response) {
+                        handleError(response);
+                });
+        }
 
 	/**
 	 *

--- a/src/main/webapp/js/proposal.js
+++ b/src/main/webapp/js/proposal.js
@@ -19,7 +19,31 @@ function proposalCtrl($rootScope, $scope, $log, $location, $routeParams, $filter
 	$scope.prevPage = params.prevPage;
 
 	$scope.chosenGenEd = null;
-	$scope.gen_eds = ["BL", "SKL", "WEL", "REL", "NWL", "NWNL", "HB", "HBSSM", "HE", "HEPT", "INTCL", "HIST", "QUANT", "WRITING", "J2"];
+	
+        // ISSUE 29 (Database-driven gen eds):
+        // Previously, gen eds were hard-coded like so:
+        // $scope.gen_eds = ["BL", "SKL", "WEL", "REL", "NWL", "NWNL", "HB", "HBSSM", "HE", "HEPT", "INTCL", "HIST", "QUANT", "WRITING", "J2"];
+        // This is not a particularly effective approach because we may need to,
+        // say, add more gen eds to the database. The solution is to make gen eds
+        // database driven. In issue-4 we added gen eds to a database. Here we
+        // retrieve those gen eds from the database. In the database, each gen ed
+        // has four attributes: name (INTCL), title (Intercultural), effective 
+        // (the date the gen ed takes effect in (new Date).toJSON()) format), and
+        // end (the date the gen ed is removed from effect in the same format as
+        // before). The code below filters the gen eds queried from the database
+        // in initData in app.js by whether they are effective. This is when
+        // the condition effective < today < end is true. Then we create a list
+        // using map of all of the names of the gen eds to get an array in the
+        // format expected in the hard-coded string above.
+        // Also see dataSrv.js, app.js, ApcDao.java, ApcController.java.
+        var someGenEds = $filter("filter")($scope.allGenEds, function(val, idx, all) {
+            today = (new Date()).toJSON();
+            genEdIsInEffect = false;
+            if (val.effective < today && val.end > today) 
+                genEdIsInEffect = true;
+            return genEdIsInEffect;
+        }, true);
+        $scope.gen_eds = $scope.allGenEds.map(function(ed) {return ed.name});
 
 	initProposal();
 

--- a/src/main/webapp/js/proposal.js
+++ b/src/main/webapp/js/proposal.js
@@ -39,8 +39,11 @@ function proposalCtrl($rootScope, $scope, $log, $location, $routeParams, $filter
         var someGenEds = $filter("filter")($scope.allGenEds, function(val, idx, all) {
             today = (new Date()).toJSON();
             genEdIsInEffect = false;
-            if (val.effective < today && val.end > today) 
-                genEdIsInEffect = true;
+            if (val.effective < today) {
+                if (val.end === null || today < val.end) {
+                    genEdIsInEffect = true;
+                }
+            }
             return genEdIsInEffect;
         }, true);
         $scope.gen_eds = $scope.allGenEds.map(function(ed) {return ed.name});


### PR DESCRIPTION
Fixes #29 

Requires gen eds to already be in the database. So #4 must be implemented! Gen eds can then be added by running add_geneds_db.sh.

Added GET request functionality for gen eds to API.
`app.js` then grabs gen ed data and filters it so only gen eds with a date greater than their effective date and less than their end date remain.
Then we add the names of all of the remaining gen eds to an array called $scope.gen_eds.
This array has the same format as the original hard-coded array.